### PR TITLE
fix: 分包路径生成问题

### DIFF
--- a/template/build/entry.js
+++ b/template/build/entry.js
@@ -1,22 +1,36 @@
 'use strict'
 const glob = require('glob')
-const { resolve } = require('./util')
+const path = require('path')
 
 // 获取指定目录下符合glob的所有文件
-function getEntry(globPath) {
-    var files = glob.sync(globPath);
+function getEntry(...globPath) {
+    var files = [];
+    globPath.forEach((path) => {
+        var pages = glob.sync(path)
+        pages.forEach((page) => {
+            files.push(page)
+        })
+    })
+
     var entries = {},
         pageName;
 
     files.forEach((entry) => {
-        pageName = entry.match(/\/(pages\/[^\/.]*\/index)\.js$/)[1];
-        entries[pageName] = entry;
+        pageName = entry.match(/([^\/.]*\/pages\/[^\/.]*\/index)\.js$/)[1];
+        if (pageName.startsWith('src')) {
+            pageName = pageName.replace('src/', '')
+        }
+        entries[pageName] = path.resolve(entry);
     })
     return entries;
 }
 
-module.exports = (()=> {
+module.exports = (() => {
     let entry = {}
-    entry = getEntry(resolve('src/pages/*/index.js'));
+    let paths = [
+        path.resolve(__dirname, '../src/pages/*/index.js'),
+        path.resolve(__dirname, '../src/*/pages/*/index.js')
+    ]
+    entry = getEntry(...paths);
     return entry
 })()

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -4,7 +4,7 @@ import VHtmlPlugin from '@megalo/vhtml-plugin'
 
 Vue.use(VHtmlPlugin)
 
-const app = new Vue( App )
+const app = new Vue(App)
 
 app.$mount()
 
@@ -14,6 +14,12 @@ export default {
     pages: [
       'pages/index/index'
     ],
+    subpackages: [{
+      root: 'packageA',
+      pages: [
+        'pages/test/index',
+      ]
+    }],
     window: {
       backgroundTextStyle: 'light',
       navigationBarBackgroundColor: '#fff',

--- a/template/src/packageA/pages/test/index.js
+++ b/template/src/packageA/pages/test/index.js
@@ -1,0 +1,6 @@
+import App from './test.vue'
+import Vue from 'vue'
+
+const app = new Vue(App)
+
+app.$mount()

--- a/template/src/packageA/pages/test/test.vue
+++ b/template/src/packageA/pages/test/test.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+      <img class="img" src="https://user-images.githubusercontent.com/20720117/48007061-c516b380-e151-11e8-8dd0-cd1b0aaaef5f.png" @touchstart="changeStat">
+      <hello-world :color="color"></hello-world>
+      <h1 class="txt" v-show="t%2==1">click logo::{{t}}</h1>
+  </div>
+</template>
+
+<script>
+import HelloWorld from '@/components/HelloWorld.vue'
+export default {
+  mpType: 'page',
+  components: {
+      HelloWorld
+  },
+  data() {
+    return {
+      t: 1,
+      color: '#007d37'
+    }
+  },
+  created() {
+  },
+  methods:{
+    changeStat: function(){
+      this.t++
+      this.color = '#'+Math.floor(Math.random()*0xffffff).toString(16)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.app {
+  padding-top: 100px;
+  .img {
+    display: block;
+    height: 120px;
+    width: 120px;
+    margin: 20px auto;
+  }
+  .txt {
+    color: #567567;
+    font-size: 13px;
+    text-align: center;
+  }
+}
+</style>

--- a/template/src/packageA/pages/test/test.vue
+++ b/template/src/packageA/pages/test/test.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="app">
       <img class="img" src="https://user-images.githubusercontent.com/20720117/48007061-c516b380-e151-11e8-8dd0-cd1b0aaaef5f.png" @touchstart="changeStat">
       <hello-world :color="color"></hello-world>
       <h1 class="txt" v-show="t%2==1">click logo::{{t}}</h1>

--- a/template/src/pages/index/index.vue
+++ b/template/src/pages/index/index.vue
@@ -3,6 +3,7 @@
       <img class="img" src="https://user-images.githubusercontent.com/20720117/48007061-c516b380-e151-11e8-8dd0-cd1b0aaaef5f.png" @touchstart="changeStat">
       <hello-world :color="color"></hello-world>
       <h1 class="txt" v-show="t%2==1">click logo::{{t}}</h1>
+      <a class="nav" url="/packageA/pages/test/index">分包测试</a>
   </div>
 </template>
 
@@ -31,18 +32,24 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.app{
+.app {
   padding-top: 100px;
-  .img{
+  .img {
     display: block;
     height: 120px;
     width: 120px;
     margin: 20px auto;
   }
-  .txt{
-      color: #567567;
-      font-size: 13px;
-      text-align: center;
+  .txt {
+    color: #567567;
+    font-size: 13px;
+    text-align: center;
+  }
+  .nav {
+    color: #008080;
+    font-size: 15px;
+    text-align: center;
+    margin-top: 20px;
   }
 }
 </style>


### PR DESCRIPTION
更新到 v0.0.7 后，分包目录仍然没有自动生成。

此次 fix 假设项目分包路径位于 `src` 目录下。自动生成后的分包路径位于`dist-${ platform }` 目录下。

由于正则基础差，路径匹配规明显可以再改善，简化代码。

