### PR TITLE
fix: generation of webpack entry points

### DIFF
--- a/template/src/index.js
+++ b/template/src/index.js
@@ -10,16 +10,23 @@ app.$mount()
 
 export default {
   config: {
-    // 页面前带有 ^ 符号的，会被编译成首页，其他页面可以选填，我们会自动把 webpack entry 里面的入口页面加进去
+    // 放在首页的页面，会被编译成首页，其他页面可以选填，我们会自动把 webpack entry 里面的入口页面加进去
     pages: [
       'pages/index/index'
     ],
     subpackages: [{
-      root: 'packageA',
-      pages: [
-        'pages/test/index',
-      ]
-    }],
+        root: 'packageA',
+        pages: [
+          'pages/test/index',
+        ]
+      },
+      {
+        root: 'pages/packageB',
+        pages: [
+          'pages/test/index',
+        ]
+      }
+    ],
     window: {
       backgroundTextStyle: 'light',
       navigationBarBackgroundColor: '#fff',

--- a/template/src/pages/index/index.vue
+++ b/template/src/pages/index/index.vue
@@ -3,7 +3,8 @@
       <img class="img" src="https://user-images.githubusercontent.com/20720117/48007061-c516b380-e151-11e8-8dd0-cd1b0aaaef5f.png" @touchstart="changeStat">
       <hello-world :color="color"></hello-world>
       <h1 class="txt" v-show="t%2==1">click logo::{{t}}</h1>
-      <a class="nav" url="/packageA/pages/test/index">分包测试</a>
+      <a class="nav" url="/packageA/pages/test/index">跳转至分包 A</a>
+      <a class="nav" url="/pages/packageB/pages/test/index">跳转至分包 B</a>
   </div>
 </template>
 

--- a/template/src/pages/packageB/pages/test/index.js
+++ b/template/src/pages/packageB/pages/test/index.js
@@ -1,0 +1,6 @@
+import App from './test.vue'
+import Vue from 'vue'
+
+const app = new Vue(App)
+
+app.$mount()

--- a/template/src/pages/packageB/pages/test/test.vue
+++ b/template/src/pages/packageB/pages/test/test.vue
@@ -21,7 +21,7 @@ export default {
   },
   created() {
     wx.setNavigationBarTitle({
-      title: '分包 A',
+      title: '分包 B',
     })
   },
   methods:{


### PR DESCRIPTION
本次 PR 做了一下修改：
- 修改了主文件配置的正则匹配规则，经测试，可正确生成页面入口和分包页面入口
- 增加了控制台错误提示
- 在 src/pages 另外增加了一个分包测试页面