### PR TITLE
fix: update package

### DIFF
--- a/template/package
+++ b/template/package
@@ -41,6 +41,6 @@
   "dependencies": {
     "@megalo/vhtml-plugin": "^0.1.0",
     "megalo": "^0.5.2",
-    "octoparse": "^0.2.0"
+    "octoparse": "^0.3.0"
   }
 }


### PR DESCRIPTION
`octoparse 0.2.x`使用`v-html`会报错`octoParse.htmlParse is not a function`
